### PR TITLE
Update application-insights.json

### DIFF
--- a/application-insights.json
+++ b/application-insights.json
@@ -7,11 +7,11 @@
     },
    
     "x-ms-parameterized-host": {
-      "hostTemplate": "{Endpoint}/v2/",
+      "hostTemplate": "{Host}/v2/",
       "useSchemePrefix": false,
       "parameters": [
         {
-          "$ref": "#/parameters/Endpoint"
+          "$ref": "#/parameters/Host"
         }
       ]
     },
@@ -1030,8 +1030,8 @@
       }
     },
     "parameters": {
-      "Endpoint": {
-        "name": "Endpoint",
+      "Host": {
+        "name": "Host",
         "description": "Breeze endpoint: https://dc.services.visualstudio.com",
         "x-ms-parameter-location": "client",
         "default": "https://dc.services.visualstudio.com",


### PR DESCRIPTION
- Rename `Endpoint` --> `Host`. Fixes duplicate `endpoint` generated by typescript extension. `endpoint` is automatically inserted into all `clientOptions`

https://github.com/markwolff/generated-applicationinsights-client/blob/e9a3d1e2864da02b08b56be6a87645cc11abfe4b/src/generated/models/index.ts#L600-L610